### PR TITLE
Feature/静的解析 log4 net 追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ github+AWS CodeBuild を検討する。
 ### コード文書化
 XML Documentation を DocFX か Sandcastle で整形する予定。  
 https://docs.microsoft.com/ja-jp/dotnet/csharp/codedoc
+
+
+## コミット
+- fix：バグ修正
+- add：機能追加
+- update：機能変更
+- remove：機能削除
+- doc：資料の修正や更新

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # TutorialMoneyAdmin
+家計簿アプリを作成。
+
+## 使用ライブラリ
+フレームワークは ASP.NET MVC 5 を利用する。MVCの理解を深める目的がある。  
+
+### フロント
+Razer, Bootstrap, jQuery。  
+ajaxはaxios。  
+
+### O/Rマッパー
+Dapper を利用する。  
+標準は Entity Framework だが大げさかつ動作が遅いので利用しない。  
+変わりに軽量な Dapper を利用する。ちなみに Dapper は厳密にはORMではないが気にしない。  
+SqlKata というクエリビルダはとてもいいらしいの導入を検討する。
+
+### DIコンテナ
+Autofac を検討する。  
+
+### ログ出力
+Log4Net を検討する。
+
+### テストコード
+MSTest を利用する。
+
+### 静的解析
+FxCopAnalyzerを検討する
+
+### CI/CD
+github+AWS CodeBuild を検討する。
+
+### コード文書化
+XML Documentation を DocFX か Sandcastle で整形する予定。  
+https://docs.microsoft.com/ja-jp/dotnet/csharp/codedoc

--- a/TutorialMoneyAdmin/.editorconfig
+++ b/TutorialMoneyAdmin/.editorconfig
@@ -1,0 +1,7 @@
+﻿[*.cs]
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1200: Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = none

--- a/TutorialMoneyAdmin/.editorconfig
+++ b/TutorialMoneyAdmin/.editorconfig
@@ -1,7 +1,19 @@
 ﻿[*.cs]
 
 # SA1600: Elements should be documented
-dotnet_diagnostic.SA1600.severity = none
+dotnet_diagnostic.SA1600.severity = warning
 
 # SA1200: Using directives should be placed correctly
 dotnet_diagnostic.SA1200.severity = none
+
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SA1629: Documentation text should end with a period
+dotnet_diagnostic.SA1629.severity = none
+
+# SA0001: XML comment analysis disabled
+dotnet_diagnostic.SA0001.severity = none

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/App.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
     メモ: Test プロジェクトにのみ適用される構成設定の App.config ファイルに
  エントリを追加します。
@@ -11,4 +11,20 @@
     <connectionStrings>
 
     </connectionStrings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/Controllers/HomeControllerTest.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/Controllers/HomeControllerTest.cs
@@ -9,9 +9,17 @@ using TutorialMoneyAdmin.Controllers;
 
 namespace TutorialMoneyAdmin.Tests.Controllers
 {
+    /// <summary>
+    /// デフォルトコントローラー.
+    /// </summary>
     [TestClass]
     public class HomeControllerTest
     {
+        /// <summary>
+        /// testtest
+        /// </summary>
+        /// <param name="test1">１つめの引数あれば使う</param>
+        /// <param name="test2">２つめの引数あれば使う</param>
         [TestMethod]
         public void Index()
         {
@@ -25,6 +33,11 @@ namespace TutorialMoneyAdmin.Tests.Controllers
             Assert.IsNotNull(result);
         }
 
+        /// <summary>
+        /// testtest
+        /// </summary>
+        /// <param name="test1">１つめの引数あれば使う</param>
+        /// <param name="test2">２つめの引数あれば使う</param>
         [TestMethod]
         public void About()
         {
@@ -38,6 +51,11 @@ namespace TutorialMoneyAdmin.Tests.Controllers
             Assert.AreEqual("Your application description page.", result.ViewBag.Message);
         }
 
+        /// <summary>
+        /// testtest
+        /// </summary>
+        /// <param name="test1">１つめの引数あれば使う</param>
+        /// <param name="test2">２つめの引数あれば使う</param>
         [TestMethod]
         public void Contact()
         {

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/Controllers/HomeControllerTest.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/Controllers/HomeControllerTest.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Web.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TutorialMoneyAdmin;
 using TutorialMoneyAdmin.Controllers;
 

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/TutorialMoneyAdmin.Tests.csproj
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/TutorialMoneyAdmin.Tests.csproj
@@ -36,6 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.15\lib\net45\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework">
       <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/TutorialMoneyAdmin.Tests.csproj
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/TutorialMoneyAdmin.Tests.csproj
@@ -111,6 +111,8 @@
   <ItemGroup>
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/TutorialMoneyAdmin.Tests.csproj
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/TutorialMoneyAdmin.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -104,6 +105,10 @@
       <Name>TutorialMoneyAdmin</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -111,8 +116,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/packages.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="log4net" version="2.0.15" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc.ja" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/packages.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/packages.config
@@ -12,4 +12,5 @@
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
+  <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/packages.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.Tests/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.AspNet.Razor.ja" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages.ja" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net472" />

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin.sln
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialMoneyAdmin", "Tutor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TutorialMoneyAdmin.Tests", "TutorialMoneyAdmin.Tests\TutorialMoneyAdmin.Tests.csproj", "{43BC1F83-EC08-4F51-AFF9-2BA69633B8C6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3B36ABD9-1F60-44B0-AFBD-893DAEF6F294}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/App_Start/BundleConfig.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/App_Start/BundleConfig.cs
@@ -2,8 +2,15 @@
 
 namespace TutorialMoneyAdmin
 {
+    /// <summary>
+    /// javascript,CSSファイルなどの読み込みを設定します。
+    /// </summary>
     public class BundleConfig
     {
+        /// <summary>
+        /// javascript,CSSファイルなどの読み込みを設定します。
+        /// </summary>
+        /// <param name="bundles">使いたいファイルを追加していく</param>
         // バンドルの詳細については、https://go.microsoft.com/fwlink/?LinkId=301862 を参照してください
         public static void RegisterBundles(BundleCollection bundles)
         {

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/App_Start/BundleConfig.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/App_Start/BundleConfig.cs
@@ -1,5 +1,4 @@
-﻿using System.Web;
-using System.Web.Optimization;
+﻿using System.Web.Optimization;
 
 namespace TutorialMoneyAdmin
 {

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/App_Start/RouteConfig.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/App_Start/RouteConfig.cs
@@ -7,8 +7,15 @@ using System.Web.Routing;
 
 namespace TutorialMoneyAdmin
 {
+    /// <summary>
+    /// ルーティングの設定
+    /// </summary>
     public class RouteConfig
     {
+        /// <summary>
+        /// ルーティングの設定をします。
+        /// </summary>
+        /// <param name="routes">ルート先</param>
         public static void RegisterRoutes(RouteCollection routes)
         {
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
@@ -16,8 +23,7 @@ namespace TutorialMoneyAdmin
             routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
-                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
-            );
+                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional });
         }
     }
 }

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
@@ -8,8 +8,17 @@ using log4net;
 
 namespace TutorialMoneyAdmin.Controllers
 {
+    /// <summary>
+    /// デフォルトのホームコントローラー
+    /// </summary>
     public class HomeController : Controller
     {
+        /// <summary>
+        /// testtest
+        /// </summary>
+        /// <param name="test1">１つめの引数あれば使う</param>
+        /// <param name="test2">２つめの引数あれば使う</param>
+        /// <returns>戻り値記載します</returns>
         public ActionResult Index()
         {
             // ログ取得
@@ -28,6 +37,12 @@ namespace TutorialMoneyAdmin.Controllers
             return View();
         }
 
+        /// <summary>
+        /// testtest
+        /// </summary>
+        /// <param name="test1">１つめの引数あれば使う</param>
+        /// <param name="test2">２つめの引数あれば使う</param>
+        /// <returns>戻り値記載します</returns>
         public ActionResult About()
         {
             ViewBag.Message = "Your application description page.";
@@ -35,6 +50,12 @@ namespace TutorialMoneyAdmin.Controllers
             return View();
         }
 
+        /// <summary>
+        /// testtest
+        /// </summary>
+        /// <param name="test1">１つめの引数あれば使う</param>
+        /// <param name="test2">２つめの引数あれば使う</param>
+        /// <returns>戻り値記載します</returns>
         public ActionResult Contact()
         {
             ViewBag.Message = "Your contact page.";

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using log4net;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.Web.Mvc;
+
 
 namespace TutorialMoneyAdmin.Controllers
 {
@@ -10,6 +12,13 @@ namespace TutorialMoneyAdmin.Controllers
     {
         public ActionResult Index()
         {
+            ILog logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+            logger.Debug("開発中のデバッグ／トレースに使用する");
+            logger.Info("情報（操作履歴等）");
+            logger.Warn("注意／警告（障害の一歩手前）");
+            logger.Error("システムが停止するまではいかない障害が発生");
+            logger.Fatal("システムが停止する致命的な障害が発生");
             return View();
         }
 

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Web;
 using System.Web.Mvc;
 
@@ -12,13 +13,17 @@ namespace TutorialMoneyAdmin.Controllers
     {
         public ActionResult Index()
         {
+            //ログ取得
             ILog logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-            logger.Debug("開発中のデバッグ／トレースに使用する");
-            logger.Info("情報（操作履歴等）");
-            logger.Warn("注意／警告（障害の一歩手前）");
-            logger.Error("システムが停止するまではいかない障害が発生");
-            logger.Fatal("システムが停止する致命的な障害が発生");
+            //ログ一覧　Info,Errorを主に使う
+            logger.Info($"{this.RouteData.Values["controller"].ToString()}コントローラーの{MethodBase.GetCurrentMethod().Name}アクションを実行しました！");
+            logger.Error($"{ this.RouteData.Values["controller"].ToString()}コントローラーの{ MethodBase.GetCurrentMethod().Name}アクションでエラー発生！");
+            //logger.Fatal($"{ this.RouteData.Values["controller"].ToString()}コントローラーの{ MethodBase.GetCurrentMethod().Name}アクションで致命的なエラー発生！至急対応してください！");
+            //logger.Error("システムが停止するまではいかない障害が発生");
+            //logger.Fatal("システムが停止する致命的な障害が発生");
+            //logger.Debug("開発中のデバッグ／トレースに使用する");
+            //logger.Info("情報（操作履歴等）");
+            //logger.Warn("注意／警告（障害の一歩手前）");
             return View();
         }
 

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Controllers/HomeController.cs
@@ -1,11 +1,10 @@
-﻿using log4net;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Web;
 using System.Web.Mvc;
-
+using log4net;
 
 namespace TutorialMoneyAdmin.Controllers
 {
@@ -13,17 +12,19 @@ namespace TutorialMoneyAdmin.Controllers
     {
         public ActionResult Index()
         {
-            //ログ取得
+            // ログ取得
             ILog logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-            //ログ一覧　Info,Errorを主に使う
+
+            // ログ一覧　Info,Errorを主に使う
             logger.Info($"{this.RouteData.Values["controller"].ToString()}コントローラーの{MethodBase.GetCurrentMethod().Name}アクションを実行しました！");
-            logger.Error($"{ this.RouteData.Values["controller"].ToString()}コントローラーの{ MethodBase.GetCurrentMethod().Name}アクションでエラー発生！");
-            //logger.Fatal($"{ this.RouteData.Values["controller"].ToString()}コントローラーの{ MethodBase.GetCurrentMethod().Name}アクションで致命的なエラー発生！至急対応してください！");
-            //logger.Error("システムが停止するまではいかない障害が発生");
-            //logger.Fatal("システムが停止する致命的な障害が発生");
-            //logger.Debug("開発中のデバッグ／トレースに使用する");
-            //logger.Info("情報（操作履歴等）");
-            //logger.Warn("注意／警告（障害の一歩手前）");
+            logger.Error($"{this.RouteData.Values["controller"].ToString()}コントローラーの{MethodBase.GetCurrentMethod().Name}アクションでエラー発生！");
+
+            // logger.Fatal($"{ this.RouteData.Values["controller"].ToString()}コントローラーの{ MethodBase.GetCurrentMethod().Name}アクションで致命的なエラー発生！至急対応してください！");
+            // logger.Error("システムが停止するまではいかない障害が発生");
+            // logger.Fatal("システムが停止する致命的な障害が発生");
+            // logger.Debug("開発中のデバッグ／トレースに使用する");
+            // logger.Info("情報（操作履歴等）");
+            // logger.Warn("注意／警告（障害の一歩手前）");
             return View();
         }
 

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Global.asax.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Global.asax.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Web;
 using System.Web.Mvc;
@@ -8,8 +9,16 @@ using System.Web.Routing;
 
 namespace TutorialMoneyAdmin
 {
+    /// <summary>
+    /// まだ何を記載すべき箇所かわからないため後日記載
+    /// </summary>
+    // SA11649の警告の抑制をしておく。
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:FileNameMustMatchTypeName", Justification = "Reviewed.")]
     public class MvcApplication : System.Web.HttpApplication
     {
+        /// <summary>
+        /// まだ何を記載すべき箇所かわからないため後日記載
+        /// </summary>
         protected void Application_Start()
         {
             AreaRegistration.RegisterAllAreas();

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Properties/AssemblyInfo.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // 既定値にすることができます:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-//log4netの設定ファイルの置き場所
-[assembly: log4net.Config.XmlConfigurator(ConfigFile = "./Log/Log4net.xml", Watch = true)]
 
+// log4netの設定ファイルの置き場所
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "./Log/Log4net.xml", Watch = true)]

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Properties/AssemblyInfo.cs
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Properties/AssemblyInfo.cs
@@ -33,3 +33,6 @@ using System.Runtime.InteropServices;
 // 既定値にすることができます:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+//log4netの設定ファイルの置き場所
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "./Log/Log4net.xml", Watch = true)]
+

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/TutorialMoneyAdmin.csproj
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/TutorialMoneyAdmin.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,6 +35,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>ConcurrencyRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -180,6 +182,10 @@
     <Content Include="Scripts\jquery-3.4.1.slim.min.map" />
     <Content Include="Scripts\jquery-3.4.1.min.map" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -213,7 +219,10 @@
       <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/TutorialMoneyAdmin.csproj
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/TutorialMoneyAdmin.csproj
@@ -47,6 +47,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.15\lib\net45\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -137,6 +140,9 @@
     <Content Include="fonts\glyphicons-halflings-regular.svg" />
     <Content Include="Global.asax" />
     <Content Include="Content\Site.css" />
+    <Content Include="Log\Log4net.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />
     <None Include="Scripts\jquery-3.4.1.intellisense.js" />

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/TutorialMoneyAdmin.csproj
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/TutorialMoneyAdmin.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>ConcurrencyRules.ruleset</CodeAnalysisRuleSet>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -145,6 +146,9 @@
     </Content>
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />
+    <Content Include="..\.editorconfig">
+      <Link>.editorconfig</Link>
+    </Content>
     <None Include="Scripts\jquery-3.4.1.intellisense.js" />
     <Content Include="Scripts\jquery-3.4.1.js" />
     <Content Include="Scripts\jquery-3.4.1.min.js" />
@@ -170,6 +174,8 @@
     <Content Include="Views\Home\About.cshtml" />
     <Content Include="Views\Home\Contact.cshtml" />
     <Content Include="Views\Home\Index.cshtml" />
+    <Content Include="stylecop.json" />
+    <Content Include="stylecop1.json" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
@@ -191,6 +197,8 @@
   <ItemGroup>
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/Web.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/Web.config
@@ -30,7 +30,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/packages.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/packages.config
@@ -19,5 +19,6 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Modernizr" version="2.8.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
+  <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/packages.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/packages.config
@@ -4,6 +4,7 @@
   <package id="bootstrap" version="3.4.1" targetFramework="net472" />
   <package id="jQuery" version="3.4.1" targetFramework="net472" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net472" />
+  <package id="log4net" version="2.0.15" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc.ja" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/packages.config
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/packages.config
@@ -12,6 +12,7 @@
   <package id="Microsoft.AspNet.Web.Optimization.ja" version="1.1.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages.ja" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net472" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/stylecop.json
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/stylecop.json
@@ -1,0 +1,14 @@
+﻿{
+  // ACTION REQUIRED: This file was automatically added to your project, but it
+  // will not take effect until additional steps are taken to enable it. See the
+  // following page for additional information:
+  //
+  // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
+
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "PlaceholderCompany"
+    }
+  }
+}

--- a/TutorialMoneyAdmin/TutorialMoneyAdmin/stylecop1.json
+++ b/TutorialMoneyAdmin/TutorialMoneyAdmin/stylecop1.json
@@ -1,0 +1,14 @@
+﻿{
+  // ACTION REQUIRED: This file was automatically added to your project, but it
+  // will not take effect until additional steps are taken to enable it. See the
+  // following page for additional information:
+  //
+  // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
+
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "PlaceholderCompany"
+    }
+  }
+}


### PR DESCRIPTION
・静的解析の導入
StyleCopAnalyzers
ドキュメント
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
参考URL
https://dotengineerblog.net/how-to-perform-statical-analysis-in-visual-studio2019/

・log4netの導入
一旦、InfoとErrorメソッドでログを出力する。
出力場所　Logフォルダのテキストファイル
参考URL
https://itsakura.com/csharp-log4net

・READMEの追記